### PR TITLE
Restructure for Satyrograpohs 0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
-PREFIX=/usr/local
-PACKAGE_NAME=satysfi-karnaugh
-PACKAGE_DEST_DIR=$(PREFIX)/share/satysfi/$(PACKAGE_NAME)
+PACKAGE_NAME=karnaugh
 
-.PHONY: all doc install uninstall
+.PHONY: doc
 
-all:
+doc: examples/examples.pdf
 
-doc:
-
-install:
-	install -d "$(PACKAGE_DEST_DIR)/packages"
-	install -m 644 karnaugh.satyh "$(PACKAGE_DEST_DIR)/packages"
-
-uninstall:
-	rm -rf "$(PACKAGE_DEST_DIR)"
+examples/examples.pdf: examples/examples.saty satysfi-$(PACKAGE_NAME).opam karnaugh.satyh Satyristes
+	opam pin add satysfi-$(PACKAGE_NAME).opam "file://$(PWD)" -y
+	satyrographos opam build -name $(PACKAGE_NAME)-doc

--- a/Satyristes
+++ b/Satyristes
@@ -1,0 +1,19 @@
+(version "0.0.2")
+(library
+  (name "karnaugh")
+  (version "0.0.1")
+  (sources
+    ((package "karnaugh.satyh" "./karnaugh.satyh")))
+  (opam "satysfi-karnaugh.opam"))
+(libraryDoc
+  (name "karnaugh-doc")
+  (version "0.0.1")
+  (workingDirectory "examples")
+  (build
+    ((satysfi "examples.saty" "-o" "examples.pdf")))
+  (sources
+    ((doc "examples.pdf" "examples/examples.pdf")
+     (doc "examples.saty" "examples/examples.saty")
+     (doc "local.satyh" "examples/local.satyh")))
+  (opam "satysfi-karnaugh-doc.opam")
+  (dependencies ((karnaugh ()))))

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,4 @@
+examples-local.saty
+karnaugh.satyh
+*.satysfi-aux
+*.pdf

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,9 @@
-examples.pdf: karnaugh.satyh local.satyh examples.saty
-	satysfi examples.saty -o examples.pdf
+examples.pdf: examples-local.saty karnaugh.satyh local.satyh
+	satysfi $< -o $@
+
+examples-local.saty: examples.saty
+	sed -e '/^@require: /s!^@require: karnaugh/!@import: !' $< > $@ 
 
 karnaugh.satyh: ../karnaugh.satyh
-	cp ../karnaugh.satyh .
+	cp $< .
 

--- a/examples/examples.saty
+++ b/examples/examples.saty
@@ -1,5 +1,5 @@
 @require: stdjareport
-@import: karnaugh
+@require: karnaugh/karnaugh
 @import: local
 
 

--- a/satysfi-karnaugh-doc.opam
+++ b/satysfi-karnaugh-doc.opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 name:         "satysfi-karnaugh"
 version:      "0.0.1"
-synopsis:     "Drawing Karnaugh maps in SATySFi"
+synopsis:     "Document: Drawing Karnaugh maps in SATySFi"
 description:  """
-Drawing Karnaugh maps in SATySFi
+Document: Drawing Karnaugh maps in SATySFi
 
 This can be installed as a package for SATySFi by Satyrographos. (https://github.com/na4zagin3/satyrographos) 
 """
@@ -14,18 +14,27 @@ bug-reports:  "https://github.com/takagiy/satysfi-karnaugh/issues"
 dev-repo:     "git+https://github.com/takagiy/satysfi-karnaugh.git"
 license:      "MIT"
 depends: [
-  "satyrographos" {>= "0.0.2" & < "0.0.3"}
+  "satysfi" {>= "0.0.3" & < "0.0.4"}
+  "satyrographos" {>= "0.0.1" & < "0.0.3"}
+  "satysfi-lib-dist"
+  "satysfi-karnaugh" {= "0.0.1"}
 ]
-build: []
+build: [
+  ["satyrographos" "opam" "build"
+   "-name" "karnaugh-doc"
+   "-prefix" "%{prefix}%"
+   "-script" "%{build}%/Satyristes"]
+]
 install: [
   ["satyrographos" "opam" "install"
-   "-name" "karnaugh"
+   "-name" "karnaugh-doc"
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
 remove: [
   ["satyrographos" "opam" "uninstall"
-   "-name" "karnaugh"
+   "-name" "karnaugh-doc"
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
+


### PR DESCRIPTION
This PR adopts new Satyrographos 0.0.2 scheme.

- Add `Satyristes` a build file.
- Update `dependency`, `install` and `uninstall` sections in the OPAM package file.
- Update `Makefile` to build the library doc, i.e., `example/example.saty`.
- Hack `examples/Makefile` for local build. This can be now replaced with `make doc` at the top directory.